### PR TITLE
Dotfiles for r4v5

### DIFF
--- a/hooks/post-up
+++ b/hooks/post-up
@@ -1,0 +1,8 @@
+#!/bin/sh
+VUNDLEDIR=$HOME/.vim/bundle/Vundle.vim
+if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
+  git clone https://github.com/gmarik/vundle.git $VUNDLEDIR 
+fi
+  vim -u $HOME/.vimrc.bundles +PluginInstall +qa
+  [ ! -e $HOME/.tmux/plugins/tpm ] && git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+

--- a/vimrc
+++ b/vimrc
@@ -1,0 +1,42 @@
+set nocompatible
+filetype off
+
+if filereadable(expand("~/.vimrc.bundles"))
+  source ~/.vimrc.bundles
+endif
+
+let g:rainbow_active = 1
+let g:ctrlp_clear_cache_on_exit = 0
+let g:ctrlp_cache_dir = $HOME.'/.cache/ctrlp'
+let g:ctrlp_show_hidden = 1
+let g:ctrlp_custom_ignore = {
+  \ 'dir': '\v[\/]\.(git|hg|svn|DS_Store)$',
+  \ 'file': '\v\.(jpg|gif|pyc|swp|pid|scssc)$',
+  \ }
+
+au BufRead,BufNewFile *.md set filetype=markdown
+
+map <C-n> :NERDTreeToggle<CR>
+map <Leader>t :CtrlP<CR>
+map <Leader>b :CtrlPBuffer<CR>
+
+syntax on
+
+set undofile
+set undodir=$HOME/.vim/undo
+set undolevels=1000
+set undoreload=10000
+
+set mouse=a
+
+
+set hlsearch
+set ignorecase
+set smartcase
+set incsearch
+set expandtab
+set shiftwidth=2
+set tabstop=2
+set number
+set numberwidth=2
+set autoindent

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -1,0 +1,18 @@
+set nocompatible
+filetype off
+set rtp+=~/.vim/bundle/Vundle.vim
+call vundle#begin()
+Plugin 'gmarik/Vundle.vim'
+Plugin 'rodjek/vim-puppet'
+Plugin 'tpope/vim-rails.git'
+Plugin 'stephpy/vim-yaml'
+Plugin 'vim-ruby/vim-ruby'
+Plugin 'tpope/vim-fugitive'
+Plugin 'oblitum/rainbow'
+Plugin 'kien/ctrlp.vim'
+Plugin 'nicwest/QQ.vim'
+Plugin 'The-NERD-Commenter'
+Plugin 'vimux'
+Plugin 'scrooloose/nerdtree'
+call vundle#end()
+filetype plugin indent on 


### PR DESCRIPTION
I use Vundle, and manage dotfiles across a bunch of machines with rcm. I have the list of vim packaages I use abstracted out of the main .vimrc; later refactoring will split package-specific configuration commands out of the main .vimrc.

The .vimrc.bundles is basically the stuff that helps me do what I need to do at work, with ruby, yaml, pupppet, and clojure-related plugins.
Among the more general stuff: CtrlP is a great CommandT implementation without the external script, but it's slow on first use unless you tell it to cache the results (as in the .vimrc). NERDTree is a file manager; if I just run 'vim' without a file or command, it starts up. QQ is a REST client thing that I haven't explored too much but which has been useful a few times. And rainbow helps me figure out what punctuation goes where.
